### PR TITLE
AddFirst now adds to the end of the index 

### DIFF
--- a/src/main/java/com/fastdtw/dtw/WarpPath.java
+++ b/src/main/java/com/fastdtw/dtw/WarpPath.java
@@ -38,7 +38,6 @@ public final class WarpPath {
         return tsIindexes.get(tsIindexes.size() - 1);
     }
 
-
     public int minJ() {
         return tsJindexes.get(tsJindexes.size() - 1);
     }
@@ -46,7 +45,6 @@ public final class WarpPath {
     public int maxI() {
         return tsIindexes.get(0);
     }
-
 
     public int maxJ() {
         return tsJindexes.get(0);
@@ -62,18 +60,16 @@ public final class WarpPath {
         tsJindexes.add(0, j);
     }
 
-
     public List<Integer> getMatchingIndexesForI(int i) {
         int index = tsIindexes.indexOf(i);
         if (index < 0)
             throw new InternalError("ERROR:  index '" + i + " is not in the " + "warp path.");
-        final List<Integer>  matchingJs = new ArrayList<Integer>(tsIindexes.size());
+        final List<Integer> matchingJs = new ArrayList<Integer>(tsIindexes.size());
         while (index < tsIindexes.size() && tsIindexes.get(index) == i)
             matchingJs.add(tsJindexes.get(index++));
 
         return matchingJs;
     }
-
 
     public List<Integer> getMatchingIndexesForJ(int j) {
         int index = tsJindexes.indexOf(j);
@@ -86,7 +82,6 @@ public final class WarpPath {
         return matchingIs;
     }
 
-
     // Create a new WarpPath that is the same as THIS WarpPath, but J is the reference template, rather than I.
     public WarpPath invertedCopy() {
         final WarpPath newWarpPath = new WarpPath();
@@ -95,7 +90,6 @@ public final class WarpPath {
 
         return newWarpPath;
     }
-
 
     // Swap I and J so that the warp path now indicates that J is the template rather than I.
     public void invert() {
@@ -106,7 +100,6 @@ public final class WarpPath {
         }
     }
 
-
     public ColMajorCell get(int index) {
         if ((index > this.size()) || (index < 0))
             throw new NoSuchElementException();
@@ -114,7 +107,7 @@ public final class WarpPath {
             return new ColMajorCell(tsIindexes.get(tsIindexes.size() - index - 1), tsJindexes.get(tsJindexes.size() - index - 1));
     }
 
-
+    @Override
     public String toString() {
         StringBuilder outStr = new StringBuilder("[");
         for (int x = 0; x < tsIindexes.size(); x++) {
@@ -128,6 +121,7 @@ public final class WarpPath {
     }
 
 
+    @Override
     public boolean equals(Object obj) {
         if ((obj instanceof WarpPath))  // trivial false test
         {
@@ -146,7 +140,7 @@ public final class WarpPath {
             return false;
     }
 
-
+    @Override
     public int hashCode() {
         return tsIindexes.hashCode() * tsJindexes.hashCode();
     }

--- a/src/main/java/com/fastdtw/dtw/WarpPath.java
+++ b/src/main/java/com/fastdtw/dtw/WarpPath.java
@@ -7,16 +7,15 @@
 
 package com.fastdtw.dtw;
 
+import com.fastdtw.matrix.ColMajorCell;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-import com.fastdtw.matrix.ColMajorCell;
-
 public final class WarpPath {
-
-    private final List<Integer> tsIindexes;
-    private final List<Integer> tsJindexes;
+    private List<Integer> tsIindexes;   // ArrayList of Integer
+    private List<Integer> tsJindexes;   // ArrayList of Integer
 
     private WarpPath(List<Integer> tsIindexes, List<Integer> tsJindexes) {
         this.tsIindexes = tsIindexes;
@@ -36,58 +35,105 @@ public final class WarpPath {
     }
 
     public int minI() {
-        return tsIindexes.get(0).intValue();
+        return tsIindexes.get(tsIindexes.size() - 1);
     }
 
+
     public int minJ() {
-        return tsJindexes.get(0).intValue();
+        return tsJindexes.get(tsJindexes.size() - 1);
     }
 
     public int maxI() {
-        return tsIindexes.get(tsIindexes.size() - 1).intValue();
+        return tsIindexes.get(0);
     }
 
+
     public int maxJ() {
-        return tsJindexes.get(tsJindexes.size() - 1).intValue();
+        return tsJindexes.get(0);
     }
 
     public void addFirst(int i, int j) {
+        tsIindexes.add(i);
+        tsJindexes.add(j);
+    }
+
+    public void addLast(int i, int j) {
         tsIindexes.add(0, i);
         tsJindexes.add(0, j);
     }
 
-    public void addLast(int i, int j) {
-        tsIindexes.add(i);
-        tsJindexes.add(j);
+
+    public List<Integer> getMatchingIndexesForI(int i) {
+        int index = tsIindexes.indexOf(i);
+        if (index < 0)
+            throw new InternalError("ERROR:  index '" + i + " is not in the " + "warp path.");
+        final List<Integer>  matchingJs = new ArrayList<Integer>(tsIindexes.size());
+        while (index < tsIindexes.size() && tsIindexes.get(index) == i)
+            matchingJs.add(tsJindexes.get(index++));
+
+        return matchingJs;
     }
+
+
+    public List<Integer> getMatchingIndexesForJ(int j) {
+        int index = tsJindexes.indexOf(j);
+        if (index < 0)
+            throw new InternalError("ERROR:  index '" + j + " is not in the " + "warp path.");
+        final List<Integer> matchingIs = new ArrayList<Integer>(tsJindexes.size());
+        while (index < tsJindexes.size() && tsJindexes.get(index) == j)
+            matchingIs.add(tsIindexes.get(index++));
+
+        return matchingIs;
+    }
+
+
+    // Create a new WarpPath that is the same as THIS WarpPath, but J is the reference template, rather than I.
+    public WarpPath invertedCopy() {
+        final WarpPath newWarpPath = new WarpPath();
+        for (int x = 0; x < tsIindexes.size(); x++)
+            newWarpPath.addLast(tsJindexes.get(x), tsIindexes.get(x));
+
+        return newWarpPath;
+    }
+
+
+    // Swap I and J so that the warp path now indicates that J is the template rather than I.
+    public void invert() {
+        for (int x = 0; x < tsIindexes.size(); x++) {
+            final int temp = tsIindexes.get(x);
+            tsIindexes.set(x, tsJindexes.get(x));
+            tsJindexes.set(x, temp);
+        }
+    }
+
 
     public ColMajorCell get(int index) {
         if ((index > this.size()) || (index < 0))
             throw new NoSuchElementException();
         else
-            return new ColMajorCell(tsIindexes.get(index).intValue(),
-                    tsJindexes.get(index).intValue());
+            return new ColMajorCell(tsIindexes.get(tsIindexes.size() - index - 1), tsJindexes.get(tsJindexes.size() - index - 1));
     }
 
-    @Override
+
     public String toString() {
-        StringBuffer outStr = new StringBuffer("[");
+        StringBuilder outStr = new StringBuilder("[");
         for (int x = 0; x < tsIindexes.size(); x++) {
-            outStr.append("(" + tsIindexes.get(x) + "," + tsJindexes.get(x) + ")");
+            outStr.append("(").append(tsIindexes.get(x)).append(",").append(tsJindexes.get(x)).append(")");
             if (x < tsIindexes.size() - 1)
                 outStr.append(",");
-        } // end for loop
+        }
+        outStr.append("]");
 
-        return new String(outStr.append("]"));
-    } // end toString()
+        return outStr.toString();
+    }
 
-    @Override
+
     public boolean equals(Object obj) {
-        if (obj == null)
-            return false;
-        if ((obj instanceof WarpPath)) {
+        if ((obj instanceof WarpPath))  // trivial false test
+        {
             final WarpPath p = (WarpPath) obj;
-            if ((p.size() == this.size()) && (p.maxI() == this.maxI()) && (p.maxJ() == this.maxJ())) {
+            if ((p.size() == this.size()) && (p.maxI() == this.maxI()) && (p.maxJ() == this.maxJ())) // less trivial reject
+            {
                 // Compare each value in the warp path for equality
                 for (int x = 0; x < this.size(); x++)
                     if (!(this.get(x).equals(p.get(x))))
@@ -100,7 +146,7 @@ public final class WarpPath {
             return false;
     }
 
-    @Override
+
     public int hashCode() {
         return tsIindexes.hashCode() * tsJindexes.hashCode();
     }

--- a/src/main/java/com/fastdtw/dtw/WarpPath.java
+++ b/src/main/java/com/fastdtw/dtw/WarpPath.java
@@ -14,8 +14,8 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 public final class WarpPath {
-    private List<Integer> tsIindexes;   // ArrayList of Integer
-    private List<Integer> tsJindexes;   // ArrayList of Integer
+    private final List<Integer> tsIindexes;
+    private final List<Integer> tsJindexes;
 
     private WarpPath(List<Integer> tsIindexes, List<Integer> tsJindexes) {
         this.tsIindexes = tsIindexes;


### PR DESCRIPTION
AddFirst it is called multiple times and slow down the performance (ArrayCopy).
AddFirst adds to the end of the index, AddLast to the top.
So we only have to invert the index access.
Everythings works and is times faster [See](https://github.com/ChronixDB/chronix.fastdtw).
